### PR TITLE
spec: add yurtle-table block type — tabular RDF (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yurtle — Markdown that becomes a knowledge graph
 
-> **Status (2026-06):** the spec is current (v2.0, Y0–Y6 layer model) and papers 101/117
+> **Status (2026-06):** the spec is current (v2.1: yurtle-table tabular RDF; Y0–Y6 layer model) and papers 101/117
 > cite this repo. In the NuSy runtime, knowledge storage moved to Arrow tables in V14 —
 > the Y-layer model defined here carries forward unchanged into the V19 Arrow Memory.
 
@@ -50,6 +50,7 @@ Yurtle pages express relationships through three complementary layers:
 | **Frontmatter** | Top of file | `---` YAML `---` | Document metadata |
 | **Content** | Body | Markdown + `[[links]]` | Human prose |
 | **Yurtle Blocks** | Anywhere | ` ```yurtle ``` ` | Inline structured data |
+| **Tabular Blocks** | Anywhere | ` ```yurtle-table ``` ` | Same-shaped subjects as a scannable, queryable table (v2.1) |
 
 This is the **"graph anywhere"** principle — relationships declared where they make sense.
 

--- a/yurtle-spec.md
+++ b/yurtle-spec.md
@@ -1,4 +1,4 @@
-# Yurtle Specification v2.0 (February 2026)
+# Yurtle Specification v2.1 (February 2026)
 
 Yurtle is minimal YAML/RDF front matter + inline blocks that turn any folder of Markdown files into a queryable knowledge graph.
 
@@ -134,6 +134,74 @@ crew:
   size: 20
 ```
 
+### Tabular Blocks (`yurtle-table`)
+
+The core thesis is *one format, two audiences*. A plain `yurtle` block is
+scannable for a single subject, but a **set of same-shaped subjects** (a
+voyage's phases, a Y-layer summary, a hypothesis→experiment→measure matrix)
+reads best as a **table** — yet a markdown table is not queryable, and writing
+both a table and a `yurtle` block duplicates the data. The `yurtle-table` fenced
+block removes the duplication: **it IS a markdown table, and it IS RDF.**
+
+~~~markdown
+```yurtle-table
+@type Phase
+
+| @id       | label                             | phase-order | phase-item        |
+|-----------|-----------------------------------|-------------|-------------------|
+| #phase-1  | Architect instruction (CLAUDE.md) | 1           | PR-187            |
+| #phase-2  | Fleet voyage awareness            | 2           | EXP-1020, EXP-1021 |
+| #phase-3  | Voyage CLI commands               | 3           | EXP-1022          |
+| #phase-4  | Research interlinks               | 4           |                   |
+```
+~~~
+
+Any markdown viewer renders the above as a table; a yurtle parser emits:
+
+```yurtle
+phase-1:
+  a: Phase
+  label: Architect instruction (CLAUDE.md)
+  phase-order: 1
+  phase-item: PR-187
+
+phase-2:
+  a: Phase
+  label: Fleet voyage awareness
+  phase-order: 2
+  phase-item:
+    - EXP-1020
+    - EXP-1021
+```
+
+*(…and so on. In Turtle: `<#phase-1> a :Phase ; :label "…" ; :phase-order 1 ; :phase-item "PR-187" .`)*
+
+**Rules**
+
+1. **Header row = predicates.** Each column header is a property key resolved
+   exactly like a `yurtle`-block key (bare key against the document vocabulary;
+   a declared-prefix CURIE such as `rdfs:label` is also accepted).
+2. **`@id` column = subject.** Required; each row's `@id` cell is that row's
+   subject (resolved against `@base` like any other id).
+3. **Type — declaration or column.** An `@type <Type>` line *before* the table
+   sets `rdf:type` for **every** row. An optional **`@type` column** sets it
+   **per row** and overrides the declaration. (Answers design Q1: both are
+   supported; column wins.)
+4. **Empty cell = no triple.** A blank cell emits nothing for that
+   (subject, predicate) — it is absence, not an empty-string value.
+5. **Multi-value cells.** A comma-separated cell emits **one triple per value**
+   (identical to a `yurtle` list) — see `phase-item` above. (Answers design Q3.)
+6. **Literals follow yurtle inference.** Values are typed the same way as
+   elsewhere in yurtle — a bare number is a numeric literal, an id-shaped token
+   (`#foo`) is a resource, everything else is a string. No `^^xsd:` annotation
+   is needed; when explicit datatyping is required, use a plain `yurtle` block
+   instead. (Answers design Q2.)
+7. **Graceful fallback.** A viewer that does not recognize `yurtle-table`
+   renders it as a fenced code block *containing a readable markdown table* —
+   still fully human-scannable, never a parse error. (Answers design Q4.)
+
+*(Parser support tracked separately in yurtle-rdflib.)*
+
 ---
 
 ## Design Principles
@@ -158,7 +226,8 @@ crew:
 
 | Version | Changes |
 |---------|---------|
-| **v2.0** | Y-layer specification (7 layers: Y0-Y6) for AI beings |
+| **v2.1** | `yurtle-table` block: tabular RDF — one markdown table, two audiences (human-scannable + machine-queryable) |
+| v2.0 | Y-layer specification (7 layers: Y0-Y6) for AI beings |
 | v1.3 | Yurtle blocks with ` ```yurtle ``` ` code fence |
 | v1.2 | Three-layer model concept |
 | v1.1 | Hierarchy (index, parent, children) |


### PR DESCRIPTION
Closes #3.

Adds a **`yurtle-table`** fenced block for a *set of same-shaped subjects* (voyage phases, Y-layer summaries, H→EXPR→M matrices): it renders as a plain markdown table (human-scannable) **and** parses as RDF (machine-queryable) — removing the write-it-twice duplication yurtle exists to solve.

**Design (resolves the issue's 4 questions):**
- Headers = predicate keys (resolved like yurtle-block keys); `@id` column = subject; `@type` is a pre-table declaration **or** a per-row column (column wins). → **Q1** both supported.
- **Q2** typed literals: follow yurtle's existing inference (number / id / string); no `^^xsd:` — use a plain `yurtle` block when explicit datatyping is needed.
- **Q3** multi-value cells: comma-separated → one triple per value (like a yurtle list).
- **Q4** fallback: unknown-block viewers render a readable markdown table, never a parse error.

**Consistency call (flag for review):** the issue's example used Turtle CURIE headers (`rdfs:label`); I reconciled to yurtle's bare `key: value` style (the spec's 'consistent syntax' principle), with declared-prefix CURIEs still accepted. Bumped spec → **v2.1** + README block-types table. Parser support tracked separately in yurtle-rdflib (a companion issue there, per the #3 'Related' note).

**Review, please:** the bare-key-vs-CURIE reconciliation, and whether v2.1 is the right version stamp. Left unmerged for a second look — this defines a public format.